### PR TITLE
Support for multiple inputs / outputs

### DIFF
--- a/inferno/trainers/basic.py
+++ b/inferno/trainers/basic.py
@@ -60,6 +60,7 @@ class Trainer(object):
         # Data logistics
         self._loaders = {}
         self._loader_iters = {}
+        self._loader_specs = {}
 
         # Iteration and epoch book-keeping
         self._iteration_count = 0
@@ -629,11 +630,22 @@ class Trainer(object):
     def dtype(self, value):
         self.set_precision(value)
 
-    def bind_loader(self, name, loader):
+    def bind_loader(self, name, loader, num_inputs=None, num_targets=1):
         assert name in ['train', 'validate', 'test']
         assert isinstance(loader, DataLoader)
         self._loaders.update({name: loader})
+        # Trainers loaded from pickle files might not have '_loader_specs', therefore:
+        if not hasattr(self, '_loader_specs'):
+            setattr(self, '_loader_specs', {})
+        self._loader_specs.update({name: {'num_inputs': num_inputs,
+                                          'num_targets': num_targets}})
         return self
+
+    def get_loader_specs(self, name):
+        assert name in self._loader_specs.keys(), \
+            "Could not find specs about loader '{}'. Valid loader names are: {}" \
+                .format(name, set(self._loader_specs.keys()))
+        return self._loader_specs.get(name)
 
     def fetch_next_batch(self, from_loader='train', restart_exhausted_generators=True,
                          update_batch_count=True, update_epoch_count_if_generator_exhausted=True):
@@ -642,7 +654,10 @@ class Trainer(object):
             self._loader_iters.update({from_loader: self._loaders[from_loader].__iter__()})
         # Try to fetch from iterator
         try:
+            # Fetch
             next_batch = next(self._loader_iters[from_loader])
+            # Verify
+            self.verify_batch(next_batch, from_loader)
             if update_batch_count:
                 self._batch_count += 1
             return next_batch
@@ -657,6 +672,41 @@ class Trainer(object):
                                              update_batch_count=update_batch_count)
             else:
                 raise
+
+    def verify_batch(self, batch, from_loader):
+        loader_specs = self.get_loader_specs(from_loader)
+        num_inputs = loader_specs.get('num_inputs')
+        num_targets = loader_specs.get('num_targets')
+        if None not in [num_inputs, num_targets]:
+            assert len(batch) == num_inputs + num_targets, \
+                "Was expecting a batch with {} (= num_inputs) + {} (= num_targets) tensors, " \
+                "got one with {} tensors.".format(num_inputs, num_targets, len(batch))
+        if num_inputs is not None:
+            assert len(batch) > num_inputs, \
+                "Expecting {} inputs, but the batch contains only {} tensors." \
+                    .format(num_inputs, len(batch))
+        if num_targets is not None:
+            assert len(batch) > num_targets, \
+                "Expecting {} outputs, but the batch contains only {} tensors." \
+                    .format(num_targets, len(batch))
+        return batch
+
+    def split_batch(self, batch, from_loader):
+        loader_specs = self.get_loader_specs(from_loader)
+        num_inputs = loader_specs.get('num_inputs')
+        num_targets = loader_specs.get('num_targets')
+        assert not (num_targets is None and num_inputs is None), \
+            "Can not split batch if both the number of inputs and targets is not known."
+        if num_inputs is None:
+            # Unknown number of inputs
+            inputs, targets = batch[:-num_targets], batch[-num_targets:]
+        elif num_targets is None:
+            # Unknown number of targets
+            inputs, targets = batch[:num_inputs], batch[num_inputs:]
+        else:
+            # Known number of inputs and targets
+            inputs, targets = batch[:num_inputs], batch[-num_targets:]
+        return inputs, pyu.from_iterable(targets)
 
     def restart_generators(self, of_loader=None):
         if of_loader is None:
@@ -796,7 +846,7 @@ class Trainer(object):
                 # Send to device and wrap as variable
                 batch = self.wrap_batch(batch)
                 # Separate inputs from targets
-                inputs, target = batch[0:-1], batch[-1]
+                inputs, target = self.split_batch(batch, from_loader='train')
                 # Compute prediction
                 prediction = self.apply_model(*inputs)
                 # Compute loss
@@ -805,7 +855,8 @@ class Trainer(object):
                 loss.backward()
             # Compute metric
             if self.metric_is_defined:
-                error = self.metric(prediction.data, target.data)
+                error = self.metric(thu.unwrap(prediction, to_cpu=False),
+                                    thu.unwrap(target, to_cpu=False))
                 self.update_state('training_error', thu.unwrap(error))
             else:
                 error = None
@@ -885,7 +936,7 @@ class Trainer(object):
                 # Wrap
                 batch = self.wrap_batch(batch, volatile=True)
                 # Separate
-                inputs, target = batch[0:-1], batch[-1]
+                inputs, target = self.split_batch(batch, from_loader='validate')
                 # Comptue output
                 output = self.apply_model(*inputs)
                 # Compute loss
@@ -895,7 +946,8 @@ class Trainer(object):
             validation_loss_meter.update(loss.data[0], n=batch_size)
             # Compute validation_error
             if self.metric_is_defined:
-                validation_error = self.metric(output.data, target.data)
+                validation_error = self.metric(thu.unwrap(output, to_cpu=False),
+                                               thu.unwrap(target, to_cpu=False))
                 if torch.is_tensor(validation_error):
                     # Convert to float
                     validation_error = validation_error[0]

--- a/inferno/utils/torch_utils.py
+++ b/inferno/utils/torch_utils.py
@@ -5,9 +5,10 @@ from torch.autograd import Variable
 from .python_utils import delayed_keyboard_interrupt
 
 
-def unwrap(tensor_or_variable, as_numpy=False):
+def unwrap(tensor_or_variable, to_cpu=True, as_numpy=False):
     if isinstance(tensor_or_variable, (list, tuple)):
-        return type(tensor_or_variable)([unwrap(_t) for _t in tensor_or_variable])
+        return type(tensor_or_variable)([unwrap(_t, to_cpu=to_cpu, as_numpy=as_numpy)
+                                         for _t in tensor_or_variable])
     elif isinstance(tensor_or_variable, Variable):
         tensor = tensor_or_variable.data
     elif torch.is_tensor(tensor_or_variable):
@@ -18,12 +19,15 @@ def unwrap(tensor_or_variable, as_numpy=False):
         return tensor_or_variable
     else:
         raise NotImplementedError
-    # Transfer to CPU, and then to numpy, and return
-    with delayed_keyboard_interrupt():
-        if as_numpy:
-            return tensor.cpu().numpy()
-        else:
-            return tensor.cpu()
+    # Transfer to CPU if required
+    if to_cpu:
+        with delayed_keyboard_interrupt():
+            tensor = tensor.cpu()
+    # Convert to numpy if required
+    if as_numpy:
+        return tensor.cpu().numpy()
+    else:
+        return tensor
 
 
 def is_tensor(object_):

--- a/inferno/utils/torch_utils.py
+++ b/inferno/utils/torch_utils.py
@@ -47,6 +47,10 @@ def is_matrix_tensor(object_):
     return is_tensor(object_) and object_.dim() == 2
 
 
+def is_scalar_tensor(object_):
+    return is_tensor(object_) and object_.dim() == 1 and object_.numel() == 1
+
+
 def where(condition, if_true, if_false):
     """
     Torch equivalent of numpy.where.

--- a/inferno/utils/train_utils.py
+++ b/inferno/utils/train_utils.py
@@ -152,3 +152,18 @@ class NoLogger(object):
         pass
 
 
+def set_state(module, key, value):
+    """Writes `key`-`value` pair to `module`'s state hook."""
+    if hasattr(module, '_state_hooks'):
+        state_hooks = getattr(module, '_state_hooks')
+        assert isinstance(state_hooks, dict), \
+            "State hook (i.e. module._state_hooks) is not a dictionary."
+        state_hooks.update({key: value})
+    else:
+        setattr(module, '_state_hooks', {key: value})
+    return module
+
+
+def get_state(module, key, default=None):
+    """Gets key from `module`'s state hooks."""
+    return getattr(module, '_state_hooks', {}).get(key, default)

--- a/tests/training/basic.py
+++ b/tests/training/basic.py
@@ -1,13 +1,15 @@
 from unittest import TestCase
 from unittest import main
 import time
+from os.path import join, dirname
 
 
 class TestTrainer(TestCase):
     # Parameters
-    ROOT_DIR = __file__
-    CUDA = True
-    HALF_PRECISION = True
+    ROOT_DIR = dirname(__file__)
+    CUDA = False
+    HALF_PRECISION = False
+    DOWNLOAD_CIFAR = False
 
     @staticmethod
     def _make_test_model():
@@ -15,11 +17,14 @@ class TestTrainer(TestCase):
         from inferno.extensions.layers.reshape import AsMatrix
 
         toy_net = nn.Sequential(nn.Conv2d(3, 128, 3, 1, 1),
+                                nn.ELU(),
                                 nn.MaxPool2d(2),
                                 nn.Conv2d(128, 128, 3, 1, 1),
+                                nn.ELU(),
                                 nn.MaxPool2d(2),
                                 nn.Conv2d(128, 256, 3, 1, 1),
-                                nn.AdaptiveMaxPool2d((1, 1)),
+                                nn.ELU(),
+                                nn.AdaptiveAvgPool2d((1, 1)),
                                 AsMatrix(),
                                 nn.Linear(256, 10),
                                 nn.Softmax())
@@ -27,56 +32,24 @@ class TestTrainer(TestCase):
 
     def test_cifar(self):
         from inferno.trainers.basic import Trainer
-        from inferno.trainers.callbacks.essentials import NaNDetector
-        import torch
-        import torchvision
-        from torchvision import transforms
-        import os
-
-        # Data preparation. Borrowed from
-        # https://github.com/kuangliu/pytorch-cifar/blob/master/main.py
-        transform_train = transforms.Compose([
-            transforms.RandomCrop(32, padding=4),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
-        ])
-
-        transform_test = transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
-        ])
-
-        trainset = torchvision.datasets.CIFAR10(root=os.path.join(self.ROOT_DIR, 'data'),
-                                                train=True, download=False,
-                                                transform=transform_train)
-        trainloader = torch.utils.data.DataLoader(trainset, batch_size=128, shuffle=True,
-                                                  num_workers=2)
-
-        testset = torchvision.datasets.CIFAR10(root=os.path.join(self.ROOT_DIR, 'data'),
-                                               train=False, download=False,
-                                               transform=transform_test)
-        testloader = torch.utils.data.DataLoader(testset, batch_size=100, shuffle=False,
-                                                 num_workers=2)
-
+        from inferno.io.box.cifar10 import get_cifar10_loaders
+        # Build cifar10 loaders
+        trainloader, testloader = get_cifar10_loaders(root_directory=join(self.ROOT_DIR, 'data'),
+                                                      download=self.DOWNLOAD_CIFAR)
         # Make model
         net = self._make_test_model()
-
         tic = time.time()
-
         # Make trainer
         trainer = Trainer(model=net)\
             .build_optimizer('Adam')\
             .build_criterion('CrossEntropyLoss')\
             .build_metric('CategoricalError')\
             .validate_every((1, 'epochs'))\
-            .save_every((1, 'epochs'), to_directory=os.path.join(self.ROOT_DIR, 'saves'))\
+            .save_every((1, 'epochs'), to_directory=join(self.ROOT_DIR, 'saves'))\
             .save_at_best_validation_score()\
-            .set_max_num_epochs(2)\
-
+            .set_max_num_epochs(2)
         # Bind trainer to datasets
         trainer.bind_loader('train', trainloader).bind_loader('validate', testloader)
-
         # Check device and fit
         if self.CUDA:
             if self.HALF_PRECISION:
@@ -85,10 +58,54 @@ class TestTrainer(TestCase):
                 trainer.cuda().fit()
         else:
             trainer.fit()
-
         toc = time.time()
-
         print("[*] Elapsed time: {} seconds.".format(toc - tic))
+
+    def test_multi_io(self):
+        from torch.utils.data.dataset import Dataset
+        from torch.utils.data.dataloader import DataLoader
+        from inferno.trainers.basic import Trainer
+        import torch
+
+        class DummyDataset(Dataset):
+            def __len__(self):
+                return 42
+
+            def __getitem__(self, item):
+                # 2 inputs and 3 targets (say)
+                return torch.rand(3, 32, 32), \
+                       torch.rand(3, 32, 32), \
+                       torch.rand(1).uniform_(), \
+                       torch.rand(1).uniform_(), \
+                       torch.rand(1).uniform_()
+
+        class DummyNetwork(torch.nn.Module):
+            def __init__(self):
+                super(DummyNetwork, self).__init__()
+                self.conv = torch.nn.Conv2d(3, 1, 3, padding=1)
+
+            def forward(self, *inputs):
+                assert len(inputs) == 2
+                out = self.conv(inputs[0])
+                return out.view(inputs[0].size(0), -1).mean(1), \
+                       out.view(inputs[0].size(0), -1).mean(1), \
+                       out.view(inputs[0].size(0), -1).mean(1)
+
+        class DummyCriterion(torch.nn.Module):
+            def forward(self, predictions, targets):
+                assert len(predictions) == len(targets) == 3
+                return predictions[0].mean()
+
+        loader = DataLoader(DummyDataset())
+        net = DummyNetwork()
+
+        trainer = Trainer(net)\
+            .build_criterion(DummyCriterion)\
+            .build_optimizer('Adam')\
+            .set_max_num_iterations(50)\
+            .bind_loader('train', loader, num_inputs=2, num_targets=3)
+
+        trainer.fit()
 
     def test_serialization(self):
         from inferno.trainers.basic import Trainer
@@ -146,6 +163,7 @@ class TestTrainer(TestCase):
 
 if __name__ == '__main__':
     tester = TestTrainer()
-    tester.ROOT_DIR = '/export/home/nrahaman/Python/Repositories/inferno/tests/training/root'
-    tester.test_multi_gpu()
-    # tester.test_serialization()
+    # tester.ROOT_DIR = '/export/home/nrahaman/Python/Repositories/inferno/tests/training/root'
+    # tester.test_multi_io()
+    tester.DOWNLOAD_CIFAR = True
+    tester.test_cifar()

--- a/tests/training/callbacks/logging/tensorboard.py
+++ b/tests/training/callbacks/logging/tensorboard.py
@@ -80,4 +80,5 @@ class TestTensorboard(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    TestTensorboard().test_tensorboard()
+    # unittest.main()


### PR DESCRIPTION
What's new: 
- `Trainer`'s `bind_loader` method now accepts additional arguments specifying the number of inputs and targets
- introduced state hooks: it's now possible to define model states (while defining the model) and have them accessible to callbacks (e.g. Tensorboard) when training (via trainer states)
- Tensorboard should now be able to handle multiple inputs / outputs and log user define states

Yet to be done: 

- [ ] Use `trainer.get_state` to directly read from `Trainer.model`'s state hooks