### PR TITLE
Python 2.7 compatability

### DIFF
--- a/inferno/io/core/concatenate.py
+++ b/inferno/io/core/concatenate.py
@@ -8,7 +8,11 @@ class Concatenate(Dataset):
     Concatenates mutliple datasets to one. This class does not implement
     synchronization primitives.
     """
-    def __init__(self, *datasets, transforms=None):
+
+    # use **kwargs and then get with default arguments instead of *datasets followed by keyword
+    # arguments, becuase the former is NOT python 2.7 compatible
+    def __init__(self, *datasets, **kwargs):
+        transforms = kwargs.get('transforms', None)
         assert all([isinstance(dataset, Dataset) for dataset in datasets])
         assert len(datasets) >= 1
         assert transforms is None or callable(transforms)

--- a/inferno/io/core/zip.py
+++ b/inferno/io/core/zip.py
@@ -8,7 +8,12 @@ class Zip(SyncableDataset):
     Zip two or more datasets to one dataset. If the datasets implement synchronization primitives,
     they are all synchronized with the first dataset.
     """
-    def __init__(self, *datasets, sync=False, transforms=None):
+
+    # use **kwargs and then get with default arguments instead of *datasets followed by keyword
+    # arguments, becuase the former is NOT python 2.7 compatible
+    def __init__(self, *datasets, **kwargs):
+        sync = kwargs.get('sync', False)
+        sync = kwargs.get('transforms', None)
         super(Zip, self).__init__()
         assert len(datasets) >= 1
         assert all([isinstance(dataset, Dataset) for dataset in datasets])


### PR DESCRIPTION
Changing '*args, keyword_arguments' to '*args, **kwargs' patterns because the former is not compatible with python 2.7.