### PR TITLE
Improved early stopping

### DIFF
--- a/inferno/io/transform/base.py
+++ b/inferno/io/transform/base.py
@@ -141,6 +141,16 @@ class Compose(object):
         self.transforms.append(transform)
         return self
 
+    def remove(self, name):
+        transform_idx = None
+        for idx, transform in enumerate(self.transforms):
+            if type(transform).__name__ == name:
+                transform_idx = idx
+                break
+        if transform_idx is not None:
+            self.transforms.pop(transform_idx)
+        return self
+
     def __call__(self, *tensors):
         intermediate = tensors
         for transform in self.transforms:

--- a/inferno/trainers/callbacks/essentials.py
+++ b/inferno/trainers/callbacks/essentials.py
@@ -175,5 +175,30 @@ class SaveAtBestValidationScore(Callback):
     The basic `Trainer` has built in support for saving at the best validation score, but this
     callback might eventually replace that functionality.
     """
-    def __init__(self):
+    def __init__(self, smoothness=0):
         super(SaveAtBestValidationScore, self).__init__()
+        # Privates
+        self._ema_validation_score = None
+        self._best_ema_validation_score = None
+        # Publics
+        self.smoothness = smoothness
+
+    def end_of_validation_run(self, **_):
+        # Get score (i.e. validation error if available, else validation loss)
+        current_validation_score = self.trainer.get_state('validation_error_averaged')
+        current_validation_score = self.trainer.get_state('validation_loss_averaged') \
+            if current_validation_score is None else current_validation_score
+        # Maintain ema
+        if self._ema_validation_score is None:
+            self._ema_validation_score = current_validation_score
+            self._best_ema_validation_score = current_validation_score
+        else:
+            self._ema_validation_score = self.smoothness * self._ema_validation_score + \
+                                         (1 - self.smoothness) * current_validation_score
+        # This overrides the default behaviour, but reduces to it if smoothness = 0
+        self.trainer._is_iteration_with_best_validation_score = \
+            self._ema_validation_score < self._best_ema_validation_score
+        # Trigger a save
+        if self.trainer._is_iteration_with_best_validation_score:
+            self.trainer.save_now = True
+        # Done

--- a/inferno/trainers/callbacks/essentials.py
+++ b/inferno/trainers/callbacks/essentials.py
@@ -167,3 +167,13 @@ class DumpHDF5Every(Callback):
             self.dump(mode='validation')
             # Clear cache
             self.clear_dump_cache()
+
+
+class SaveAtBestValidationScore(Callback):
+    """
+    Triggers a save at the best EMA (exponential moving average) validation score.
+    The basic `Trainer` has built in support for saving at the best validation score, but this
+    callback might eventually replace that functionality.
+    """
+    def __init__(self):
+        super(SaveAtBestValidationScore, self).__init__()


### PR DESCRIPTION
Implemented a `SaveAtBestValidationScore` callback that supports smoothing the validation curve and triggering a save only when the current smoothed validation score is better than the best smoothed validation score. The `smoothness` is specified as a parameter. 