### PR TITLE
Callback for Automatic LR Decay and Improved IOU

### DIFF
--- a/inferno/extensions/metrics/categorical.py
+++ b/inferno/extensions/metrics/categorical.py
@@ -41,10 +41,11 @@ class CategoricalError(Metric):
 
 class IOU(Metric):
     """Intersection over Union. """
-    def __init__(self, ignore_class=None, eps=1e-6):
+    def __init__(self, ignore_class=None, sharpen_prediction=False, eps=1e-6):
         super(IOU, self).__init__()
         self.eps = eps
         self.ignore_class = ignore_class
+        self.sharpen_prediction = sharpen_prediction
 
     def forward(self, prediction, target):
         # Assume that is one of:
@@ -61,6 +62,8 @@ class IOU(Metric):
         #   target.shape = (N, C)
         # First, reshape prediction to (C, -1)
         flattened_prediction = flatten_samples(prediction)
+        # Take measurements
+        num_classes, num_samples = flattened_prediction.size()
         # We need to figure out if the target is a int label tensor or a onehot tensor.
         # The former always has one dimension less, so
         if target.dim() == (prediction.dim() - 1):
@@ -73,7 +76,6 @@ class IOU(Metric):
             # Reshape target to (1, -1) for it to work with scatter
             flattened_target = target.view(1, -1)
             # Convert target to onehot with shape (C, -1)
-            num_classes, num_samples = flattened_prediction.size()
             # Make sure the target is consistent
             assert_(target.max() < num_classes)
             onehot_targets = flattened_prediction \
@@ -87,6 +89,16 @@ class IOU(Metric):
             raise ShapeError("Target must have the same number of dimensions as the "
                              "prediction, or one less. Got target.dim() = {} but "
                              "prediction.dim() = {}.".format(target.dim(), prediction.dim()))
+        # Sharpen prediction if required to. Sharpening in this sense means to replace
+        # the max predicted probability with 1.
+        if self.sharpen_prediction:
+            _, predicted_classes = torch.max(flattened_prediction, 0)
+            # Case for pytorch 0.2, where predicted_classes is (N,) instead of (1, N)
+            if predicted_classes.dim() == 1:
+                predicted_classes = predicted_classes.view(1, -1)
+            # Scatter
+            flattened_prediction = flattened_prediction\
+                .new(num_classes, num_samples).zero_().scatter_(0, predicted_classes, 1)
         # Now to compute the IOU = (a * b).sum()/(a**2 + b**2 - a * b).sum()
         # We sum over all samples to obtain a classwise iou
         numerator = (flattened_prediction * onehot_targets).sum(-1)

--- a/inferno/extensions/metrics/categorical.py
+++ b/inferno/extensions/metrics/categorical.py
@@ -96,13 +96,15 @@ class IOU(Metric):
         classwise_iou = numerator.div_(denominator)
         # If we're ignoring a class, don't count its contribution to the mean
         if self.ignore_class is not None:
-            assert_(self.ignore_class < onehot_targets.size(0),
+            ignore_class = self.ignore_class \
+                if self.ignore_class != -1 else onehot_targets.size(0) - 1
+            assert_(ignore_class < onehot_targets.size(0),
                     "`ignore_class` = {} must be at least one less than the number "
-                    "of classes = {}.".format(self.ignore_class, onehot_targets.size(0)),
+                    "of classes = {}.".format(ignore_class, onehot_targets.size(0)),
                     ValueError)
             num_classes = onehot_targets.size(0)
             dont_ignore_class = list(range(num_classes))
-            dont_ignore_class.pop(self.ignore_class)
+            dont_ignore_class.pop(ignore_class)
             if classwise_iou.is_cuda:
                 dont_ignore_class = torch.cuda.LongTensor(dont_ignore_class)
             else:

--- a/inferno/trainers/callbacks/base.py
+++ b/inferno/trainers/callbacks/base.py
@@ -125,6 +125,7 @@ class Callback(object):
     """Recommended (but not required) base class for callbacks."""
     def __init__(self):
         self._trainer = None
+        self._debugging = False
 
     @property
     def trainer(self):
@@ -158,3 +159,11 @@ class Callback(object):
 
     def __setstate__(self, state):
         self.set_config(state)
+
+    def toggle_debug(self):
+        self._debugging = not self._debugging
+        return self
+
+    def debug_print(self, message):
+        if self._debugging:
+            self.trainer.print("[DEBUG::{}] {}".format(type(self).__name__, message))

--- a/inferno/trainers/callbacks/scheduling.py
+++ b/inferno/trainers/callbacks/scheduling.py
@@ -58,6 +58,7 @@ class AutoLRDecay(Callback):
         self.monitor = monitor
         self.monitor_while = monitor_while
         self.patience = patience
+        self.cooldown_duration = cooldown_duration
         self.factor = factor
         self.required_minimum_relative_improvement = required_minimum_relative_improvement
         self.exclude_param_groups = pyu.to_iterable(exclude_param_groups) \

--- a/inferno/trainers/callbacks/scheduling.py
+++ b/inferno/trainers/callbacks/scheduling.py
@@ -5,7 +5,7 @@ from .base import Callback
 
 
 class AutoLRDecay(Callback):
-    def __init__(self, by_factor, patience, monitor='auto', monitor_momentum=0,
+    def __init__(self, factor, patience, monitor='auto', monitor_momentum=0,
                  monitor_while='auto', exclude_param_groups=None, verbose=False):
         super(AutoLRDecay, self).__init__()
         # Privates
@@ -18,10 +18,10 @@ class AutoLRDecay(Callback):
         self._best_monitor_value = None
         # Publics
         self.patience = patience
-        self.factor = by_factor
+        self.factor = factor
         self.exclude_param_groups = pyu.to_iterable(exclude_param_groups) \
             if exclude_param_groups is not None else None
-        self.verbose = False
+        self.verbose = verbose
 
     @property
     def patience(self):
@@ -176,6 +176,10 @@ class AutoLRDecay(Callback):
                     self.trainer.print("Monitor '{}' has not improved, decaying LR."
                                        .format(self.monitor))
                 self.decay()
+            else:
+                if self.verbose:
+                    self.trainer.print("Monitor '{}' has improved or in cooldown, not decaying LR."
+                                       .format(self.monitor))
             self.maintain_monitor_moving_average()
 
     def end_of_validation_run(self, **_):
@@ -185,4 +189,8 @@ class AutoLRDecay(Callback):
                     self.trainer.print("Monitor '{}' has not improved, decaying LR."
                                        .format(self.monitor))
                 self.decay()
+            else:
+                if self.verbose:
+                    self.trainer.print("Monitor '{}' has improved or in cooldown, not decaying LR."
+                                       .format(self.monitor))
             self.maintain_monitor_moving_average()

--- a/inferno/trainers/callbacks/scheduling.py
+++ b/inferno/trainers/callbacks/scheduling.py
@@ -14,6 +14,9 @@ class AutoLRDecay(Callback):
         self._last_improved_at = {'iteration_count': None, 'epoch_count': None}
         self._monitor_value_moving_average = MovingAverage(momentum=monitor_momentum)
         self._best_monitor_value = None
+        # Don't worry about these, these are properties
+        self._monitor_while = 'auto'
+        self._monitor = 'auto'
         # Publics
         self.monitor = monitor
         self.monitor_while = monitor_while

--- a/inferno/trainers/callbacks/scheduling.py
+++ b/inferno/trainers/callbacks/scheduling.py
@@ -1,0 +1,176 @@
+from ...utils.train_utils import Duration, MovingAverage
+from ...utils import python_utils as pyu
+from ...utils.exceptions import assert_
+from .base import Callback
+
+
+class AutoLRDecay(Callback):
+    def __init__(self, by_factor, patience, monitor='auto', monitor_momentum=0,
+                 monitor_while='auto', exclude_param_groups=None):
+        super(AutoLRDecay, self).__init__()
+        # Privates
+        self._patience = None
+        self._last_decayed_at = {'iteration_count': None, 'epoch_count': None}
+        self._last_improved_at = {'iteration_count': None, 'epoch_count': None}
+        self._monitor = monitor
+        self._monitor_while = monitor_while
+        self._monitor_value_moving_average = MovingAverage(momentum=monitor_momentum)
+        self._best_monitor_value = None
+        # Publics
+        self.patience = patience
+        self.factor = by_factor
+        self.exclude_param_groups = pyu.to_iterable(exclude_param_groups) \
+            if exclude_param_groups is not None else None
+
+    @property
+    def patience(self):
+        return self._patience
+
+    @patience.setter
+    def patience(self, value):
+        self._patience = Duration.build_from(value)
+
+    @property
+    def monitor(self):
+        return self._monitor
+
+    @monitor.setter
+    def monitor(self, value):
+        self._monitor = value
+
+    @property
+    def monitor_value(self):
+        return self.get_monitor_value()[0]
+
+    @property
+    def monitor_while(self):
+        monitor_value, monitor = self.get_monitor_value()
+        if self._monitor_while != 'auto':
+            return self._monitor_while
+        elif monitor.startswith('training_'):
+            return 'training'
+        elif monitor.startswith('validation_'):
+            return 'validation'
+        else:
+            raise RuntimeError("Could not parse `monitor_while`. Please provide one manually.")
+
+    @monitor_while.setter
+    def monitor_while(self, value):
+        value_mapping = {'auto': 'auto',
+                         'training': 'training',
+                         'validation': 'validation',
+                         'validating': 'validation'}
+        value = value_mapping.get(value)
+        assert_(value is not None,
+                "`monitor_while` must be one of {}, got {} instead."
+                .format(value_mapping.keys(), value),
+                ValueError)
+        self._monitor_while = value
+
+    def get_monitor_value(self):
+        if self._monitor == 'auto':
+            # Try to get validation error
+            monitor_value = self.trainer.get_state('validation_error_averaged')
+            if monitor_value is not None:
+                return monitor_value, 'validation_error_averaged'
+            monitor_value = self.trainer.get_state('validation_loss_averaged')
+            if monitor_value is not None:
+                return monitor_value, 'validation_loss_averaged'
+            monitor_value = self.trainer.get_state('training_error')
+            if monitor_value is not None:
+                return monitor_value, 'training_error'
+            monitor_value = self.trainer.get_state('training_loss')
+            if monitor_value is not None:
+                return monitor_value, 'training_loss'
+            else:
+                raise RuntimeError("Could not auto-fetch a monitor_value. "
+                                   "Please specify a monitor manually.")
+        else:
+            monitor_value = self.trainer.get_state(self._monitor)
+            assert_(monitor_value is not None,
+                    "Could not fetch the specified monitor ('{}') from trainer's state."
+                    .format(self._monitor),
+                    ValueError)
+            return monitor_value, self._monitor
+
+    @property
+    def duration_since_last_decay(self):
+        since_last_decayed = {}
+        if self._last_decayed_at.get('iteration_count') is None:
+            since_last_decayed.update({'iteration_count': self.trainer.iteration_count})
+        else:
+            since_last_decayed.update(
+                {'iteration_count': (self.trainer.iteration_count -
+                                     self._last_decayed_at['iteration_count'])
+                 })
+
+        if self._last_decayed_at.get('epoch_count') is None:
+            since_last_decayed.update({'epoch_count': self.trainer.epoch_count})
+        else:
+            since_last_decayed.update(
+                {'epoch_count': (self.trainer.epoch_count -
+                                 self._last_decayed_at['epoch_count'])
+                 })
+        return since_last_decayed
+
+    @property
+    def duration_since_last_improvment(self):
+        since_last_improved = {}
+        if self._last_improved_at.get('iteration_count') is None:
+            since_last_improved.update({'iteration_count': self.trainer.iteration_count})
+        else:
+            since_last_improved.update(
+                {'iteration_count': (self.trainer.iteration_count -
+                                     self._last_improved_at['iteration_count'])
+                 })
+
+        if self._last_improved_at.get('epoch_count') is None:
+            since_last_improved.update({'epoch_count': self.trainer.epoch_count})
+        else:
+            since_last_improved.update(
+                {'epoch_count': (self.trainer.epoch_count -
+                                 self._last_improved_at['epoch_count'])
+                 })
+        return since_last_improved
+
+    @property
+    def in_cooldown(self):
+        return self.patience.match(**self.duration_since_last_improvment)
+
+    def decay(self):
+        # TODO
+        # ...
+        self._last_decayed_at.update({'iteration_count': self.trainer.iteration_count,
+                                      'epoch_count': self.trainer.epoch_count})
+
+    def maintain_monitor_moving_average(self):
+        monitor_value = self.monitor_value
+        self._monitor_value_moving_average.update(monitor_value)
+        if self._best_monitor_value is None:
+            self._best_monitor_value = monitor_value
+
+    @property
+    def monitor_value_has_improved(self):
+        if self._monitor_value_moving_average.val is None:
+            return True
+        else:
+            monitor_value_has_improved = \
+                self._monitor_value_moving_average.val < self._best_monitor_value
+            if monitor_value_has_improved:
+                self._best_monitor_value = self._monitor_value_moving_average.val
+                self._last_improved_at.update({'iteration_count': self.trainer.iteration_count,
+                                               'epoch_count': self.trainer.epoch_count})
+            return monitor_value_has_improved
+
+    def end_of_training_iteration(self, **_):
+        # Decay if we're not in cooldown (and monitoring while training)
+        if self.monitor_while == 'training':
+            if not self.monitor_value_has_improved and not self.in_cooldown:
+                self.decay()
+            self.maintain_monitor_moving_average()
+
+    def end_of_validation_run(self, **_):
+        if self.monitor_while == 'validation':
+            if not self.monitor_value_has_improved and not self.in_cooldown:
+                self.decay()
+            self.maintain_monitor_moving_average()

--- a/inferno/trainers/callbacks/scheduling.py
+++ b/inferno/trainers/callbacks/scheduling.py
@@ -5,9 +5,42 @@ from .base import Callback
 
 
 class AutoLRDecay(Callback):
+    """
+    Callback to decay the learning rate automatically when a specified monitor
+    stops improving.
+
+    The monitor should be decreasing, i.e. lower value --> better performance.
+    """
     def __init__(self, factor, patience, required_minimum_relative_improvement=0,
                  monitor='auto', monitor_momentum=0, monitor_while='auto',
                  exclude_param_groups=None, verbose=False):
+        """
+        Parameters
+        ----------
+        factor : float
+            Factor to decay the learning rate by. Should be between 0 and 1.
+        patience : str or tuple or inferno.utils.train_utils.Duration
+            Specifies how long to wait for an improvement before a LR decay is triggered.
+        required_minimum_relative_improvement : float
+            Specifies by how much (as a fraction of the current value) the monitor should
+            improve to consider the improvement significant. Leaving this to zero implies
+            the monitor will be considered improving even if it's only so slightly better.
+        monitor : str
+            Specifies the monitor. Monitor must be a trainer state, and decrease with
+            increasing performance. Examples: 'validation_error', 'training_loss'.
+            The monitor can be 'auto' in which case it's recommended that you specify
+            `monitor_while`.
+        monitor_momentum : float
+            A momentum to smooth the monitor history with. Usually recommended to smooth out
+            any fluctuations in the monitor value.
+        monitor_while : {'auto', 'training', 'validating'}
+            Whether to monitor while training or validating. If the monitor is specified
+            (i.e. is not 'auto'), this can be left to 'auto'.
+        exclude_param_groups : int or list
+            Parameter groups to __not__ apply the LR decay on.
+        verbose : bool
+            Specifies if a message be printed before decaying.
+        """
         super(AutoLRDecay, self).__init__()
         # Privates
         self._patience = None

--- a/inferno/utils/train_utils.py
+++ b/inferno/utils/train_utils.py
@@ -27,6 +27,23 @@ class AverageMeter(object):
         self.avg = self.sum / self.count
 
 
+class Momentum(object):
+    """Computes the moving average of a given float."""
+    def __init__(self, smoothing=0):
+        self.smoothing = smoothing
+        self.val = None
+
+    def reset(self):
+        self.val = None
+
+    def update(self, val):
+        if self.val is None:
+            self.val = val
+        else:
+            self.val = self.smoothing * self.val + (1 - self.smoothing) * val
+        return self.val
+
+
 class CLUI(object):
     """Command Line User Interface"""
 
@@ -171,7 +188,7 @@ class Frequency(object):
         return "{} {}".format(self.value, self.units)
 
     def __repr__(self):
-        return "Frequency(value={}, units={})".format(self.value, self.units)
+        return "{}(value={}, units={})".format(type(self).__name__, self.value, self.units)
 
     @classmethod
     def from_string(cls, string):
@@ -200,6 +217,18 @@ class Frequency(object):
             return cls.from_string(args)
         else:
             raise NotImplementedError
+
+
+class Duration(Frequency):
+    """Like frequency, but measures a duration."""
+    def match(self, iteration_count=None, epoch_count=None, when_equal_return=False, **_):
+        match_value = {'iterations': iteration_count, 'epochs': epoch_count}.get(self.units)
+        assert_(match_value is not None,
+                "Could not match duration because {} is not known.".format(self.units),
+                ValueError)
+        if match_value == self.value:
+            return when_equal_return
+        return match_value > self.value
 
 
 class NoLogger(object):

--- a/inferno/utils/train_utils.py
+++ b/inferno/utils/train_utils.py
@@ -27,10 +27,10 @@ class AverageMeter(object):
         self.avg = self.sum / self.count
 
 
-class Momentum(object):
+class MovingAverage(object):
     """Computes the moving average of a given float."""
-    def __init__(self, smoothing=0):
-        self.smoothing = smoothing
+    def __init__(self, momentum=0):
+        self.momentum = momentum
         self.val = None
 
     def reset(self):
@@ -40,7 +40,7 @@ class Momentum(object):
         if self.val is None:
             self.val = val
         else:
-            self.val = self.smoothing * self.val + (1 - self.smoothing) * val
+            self.val = self.momentum * self.val + (1 - self.momentum) * val
         return self.val
 
 

--- a/inferno/utils/train_utils.py
+++ b/inferno/utils/train_utils.py
@@ -32,16 +32,26 @@ class MovingAverage(object):
     def __init__(self, momentum=0):
         self.momentum = momentum
         self.val = None
+        self.previous = None
 
     def reset(self):
         self.val = None
 
     def update(self, val):
+        self.previous = self.val
         if self.val is None:
             self.val = val
         else:
             self.val = self.momentum * self.val + (1 - self.momentum) * val
         return self.val
+
+    @property
+    def relative_change(self):
+        if None not in [self.val, self.previous]:
+            relative_change = (self.previous - self.val) / self.previous
+            return relative_change
+        else:
+            return None
 
 
 class CLUI(object):

--- a/tests/extensions/metrics/categorical.py
+++ b/tests/extensions/metrics/categorical.py
@@ -44,7 +44,7 @@ class TestCategorical(unittest.TestCase):
         iou_class_0 = (3 * 3) / (4 * 4)
         iou_class_1 = 0
         expected_mean_iou = 0.5 * (iou_class_0 + iou_class_1)
-        iou = IOU(ignore_class=2)(predicted_image[None, ...], target_image[None, ...])
+        iou = IOU(ignore_class=-1)(predicted_image[None, ...], target_image[None, ...])
         self.assertAlmostEqual(iou, expected_mean_iou, places=4)
 
 if __name__ == '__main__':

--- a/tests/utils/train_utils.py
+++ b/tests/utils/train_utils.py
@@ -31,6 +31,15 @@ class FrequencyTest(unittest.TestCase):
         self.assertEqual(frequency.value, np.inf)
         self.assertEqual(frequency.units, frequency.UNIT_PRIORITY)
 
+    def test_duration(self):
+        duration = tu.Duration.build_from((3, 'iterations'))
+        self.assertFalse(duration.match(iteration_count=2))
+        self.assertFalse(duration.match(iteration_count=3))
+        self.assertTrue(duration.match(iteration_count=3, when_equal_return=True))
+        self.assertTrue(duration.match(iteration_count=4))
+        with self.assertRaises(ValueError):
+            duration.match(epoch_count=2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `AutoLRDecay` callback should resemble Keras' `ReduceLROnPlateau`, but:
* the durations (i.e. patience and cooldown) can be specified in units of either epochs or iterations. 
* one could specify the `required_minimum_relative_improvement` to decide when an improvement should be considered significant (and not just noise),
* the history can be smoothed with a given `monitor_momentum`. 

Improvements in IOU include the option of sharpening the predictions (mapping `max --> 1`) before evaluating. 